### PR TITLE
Boleto HTML - 'R$' duplicado

### DIFF
--- a/src/Boleto/Render/view/boleto.blade.php
+++ b/src/Boleto/Render/view/boleto.blade.php
@@ -28,7 +28,7 @@
                 </ul>
                 <span class="header">Linha Digitável: {{ $linha_digitavel }}</span>
                 <span class="header">Número: {{ $numero }}</span>
-                {!! $valor ? '<span class="header">Valor: R$' . $valor . '</span>' : '' !!}
+                {!! $valor ? '<span class="header">Valor: ' . $valor . '</span>' : '' !!}
                 <br>
             </div>
         @endif


### PR DESCRIPTION
Símbolo "R$" exibido na versão HTML do boleto (Santander) está duplicado.
exemplo de exibição: 
Valor: R$R$ 10,00
Print: https://user-images.githubusercontent.com/27303555/63264174-cd635980-c260-11e9-9162-b635f3e93ad4.png
